### PR TITLE
Remove Brazilian election day

### DIFF
--- a/countries/BR.json
+++ b/countries/BR.json
@@ -6,7 +6,6 @@
     { "name": "Tiradentes"              , "rule": "April 21st" },    
     { "name": "Dia do Trabalhador"      , "rule": "May 1st" }, 
     { "name": "Dia da Independência"    , "rule": "September 7th" },
-    { "name": "Eleições"                , "rule": "First Sunday of October"},
     { "name": "Nossa Senhora Aparecida" , "rule": "October 12th"},
     { "name": "Dia de Finados"          , "rule": "November 2nd"},
     { "name": "Proclamação da República", "rule": "November 15th"},


### PR DESCRIPTION
A user reminded me that Brazilian elections only happen every four years,
the last being in 2014. Unless there's a mechanism for making a holiday
recur once every X years, we could probably do without it.