### PR TITLE
Fix holidays names for Poland

### DIFF
--- a/data/PL.json
+++ b/data/PL.json
@@ -1,9 +1,9 @@
 [
     { "name" : "Nowy Rok",                               "rule" : "January 1st" },
     { "name" : "Święto Trzech Króli",                    "rule" : "January 6th" },
-    { "name" : "Święto Państwowe",                       "rule" : "May 1st" },
+    { "name" : "Święto Pracy",                           "rule" : "May 1st" },
     { "name" : "Święto Narowode Trzeciego Maja",         "rule" : "May 3rd" },
-    { "name" : "Wniebowzięcie Najświętszej Marii Panny", "rule" : "August 15th" },
+    { "name" : "Wniebowzięcie Najświętszej Maryi Panny", "rule" : "August 15th" },
     { "name" : "Uroczystość Wszystkich Świętych",        "rule" : "November 1st" },
     { "name" : "Narodowe Święto Niepodległości",         "rule" : "November 11th" },
     { "name" : "Pierwszy dzień Bożego Narodzenia",       "rule" : "December 25th" },


### PR DESCRIPTION
I just noticed that holidays names for Poland are not correct. I changed "Święto Państwowe" to "Święto Pracy" and fixed spelling of "Maryi", as it should be "Wniebowzięcie Najświętszej Maryi Panny" instead of "Wniebowzięcie Najświętszej Marii Panny".