### PR TITLE
CA.json update, includes 2 missed Canadian Holidays

### DIFF
--- a/data/CA.json
+++ b/data/CA.json
@@ -14,6 +14,9 @@
         "name": "Canada Day",
         "rule": "July 1st" 
     }, { 
+        "name": "Civic Holiday",
+        "rule": "First Monday of August" 
+    }, {
         "name": "Labor Day",
         "rule": "First Monday of September" 
     }, { 
@@ -25,5 +28,8 @@
     }, {
         "name": "Christmas",
         "rule": "December 25th" 
+    }, {
+        "name": "Boxing Day",
+        "rule": "December 26th" 
     }
 ]


### PR DESCRIPTION
Was missing two Canadian Stat holidays. 
- Civic Holiday, which comes after Canada day and before Labor Day
- Boxing Day, which is the day after Christmas.

Used http://vpcalendar.net/Holiday_Dates/Holiday_Determinations.html which was a great reference to find the date rules for these missed holidays.

Though untested, I mimicked the formatting of the existing working date rules in this json file that matched the desired type of rule needed. I double and triple checked the syntax, so it should work bug free.

Great API by the way. Very nicely structured in the way it uses the raw rules to calculate the dates :) Super easy to add new ones too!